### PR TITLE
Remove quotes from font-family declaration

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -321,7 +321,7 @@ img.center {
 
 body, table.body, h1, h2, h3, h4, h5, h6, p, td { 
   color: #222222;
-  font-family: "Helvetica", "Arial", sans-serif; 
+  font-family: Helvetica, Arial, sans-serif; 
   font-weight: normal; 
   padding:0; 
   margin: 0;


### PR DESCRIPTION
Remove quotes from font-family declaration as they are not needed and created inconsistency with the declaration elsewhere in the document. It is minor.

_Litmus Tests_
- [Basic](https://litmus.com/pub/2ed7193)
- [Hero](https://litmus.com/pub/c5b1dfb)
- [Hero Sidebar](https://litmus.com/pub/2ca6316)
- [Sidebar](https://litmus.com/pub/6b613f4)
