### PR TITLE
Allow overriding the default grids

### DIFF
--- a/scss/ink/components/_grid.scss
+++ b/scss/ink/components/_grid.scss
@@ -10,7 +10,7 @@
 $include-html-grid-classes: $include-html-classes !default;
 $include-html-sub-colums-grid-classes: $include-html-grid-classes !default;
 
-$total-columns: 12;
+$total-columns: 12 !default;
 
 $wrapper-padding-top: 10px !default;
 $column-cell-padding-bottom: 10px !default;


### PR DESCRIPTION
Fixed a missing !default which prevented the number of columns in a grid from being updated.