### PR TITLE
Rename package to sassy-ink in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "ink",
-  "version": "1.0.5",
-  "main": ["./css/ink.css"],
+  "name": "sassy-ink",
+  "version": "1.0.0",
+  "main": ["./scss/ink.scss"],
   "ignore": [
     "**/.*",
     "docs",


### PR DESCRIPTION
Without this, the package name will collide with the original ink package in Bower.

In addition to merging this request, the package needs to be registered at bower.io

Also creating a git version tag (e.g. 1.0.0) would be very necessary for serious use.
